### PR TITLE
Fix Deployment Error During Bundler Installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer "Faizal Zakaria<faizal@caterspot.com>"
 
 RUN apk add --no-cache git openssh build-base
 
-RUN gem install bundler
+RUN gem install bundler -v '1.17.3'
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
## Context
Peg bundler version to fix below error during deployment:

```
  #8 [3/5] RUN gem install bundler
  #8 73.48 ERROR:  Error installing bundler:
  #8 73.48 	The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.4.22. Try installing it with `gem install bundler -v 2.4.22`
  #8 73.48 	bundler requires Ruby version >= 3.0.0. The current ruby version is 2.7.5.203.
  #8 ERROR: process "/bin/sh -c gem install bundler" did not complete successfully: exit code: 1
  ------
   > [3/5] RUN gem install bundler:
  73.48 ERROR:  Error installing bundler:
  73.48 	The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.4.22. Try installing it with `gem install bundler -v 2.4.22`
  73.48 	bundler requires Ruby version >= 3.0.0. The current ruby version is 2.7.5.203.
  ------
  Dockerfile:7
  --------------------
     5 |     RUN apk add --no-cache git openssh build-base
     6 |
     7 | >>> RUN gem install bundler
     8 |
     9 |     COPY entrypoint.sh /entrypoint.sh
  --------------------
  ERROR: failed to solve: process "/bin/sh -c gem install bundler" did not complete successfully: exit code: 1
  Warning: Docker build failed with exit code 1, back off 3.156 seconds before retry.
  /usr/bin/docker build -t 068db8:606d98539aab46d7b619172509d37f27 -f "/home/runner/work/_actions/caterspot/octopus-action/master/Dockerfile" "/home/runner/work/_actions/caterspot/octopus-action/master"
  #0 building with "default" instance using docker driver
```